### PR TITLE
Suggest installing package that provides libbabeltrace.so

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ generated using [Linux Trace Toolkit next generation](http://lttng.org/) (LTTng)
 
 To use Tmds.Babeltrace you need *libbabeltrace* on your system.
 
-Fedora: `dnf install libbabeltrace`
+Fedora: `dnf install libbabeltrace-devel`
 
 The following example iterates over all events and prints out the event name, each field's name and its type.
 


### PR DESCRIPTION
Only the -devel package provides `libbabeltrace.so` and `libbabeltrace-ctf.so`. The non-devel packages provide versioned shared objects (such as `libbabeltrace.so.1.0.0`) only.